### PR TITLE
fabric.mod.json Immersive Portals dependency

### DIFF
--- a/.github/workflows/publish_minecraft_mod.yml
+++ b/.github/workflows/publish_minecraft_mod.yml
@@ -5,8 +5,8 @@ on: [ pull_request, workflow_dispatch ]           #When your Github Action will 
 env:                                              #Environment variables that can later be referenced using ${{ env.MINECRAFT_VERSION }}. These are useful for repeating information and allow for quick changes for new mod updates
   MINECRAFT_VERSION: 1.19.2
   JAVA_VERSION: 17
-  MOD_VERSION: 0.3.0-1.19.2
-  MOD_RELEASE_NAME: Immersive Portals 0.3.0 for Minecraft 1.19.2
+  MOD_VERSION: 0.3.1-1.19.2
+  MOD_RELEASE_NAME: Immersive Portals 0.3.1 for Minecraft 1.19.2
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,2 @@
-- reworked portal functionality using Immersive Portals instead of Custom Portal API
-  - Portal entities stored in and managed by MagneticDistortionSystemControlComputerBlockEntity
-  - PortalStorage class extending PersistentState class to track multiple entrance portals for one destination portal
-  - Many other changes related to those listed above which aren't listed explicitly here
+- re-added Immersive Portals dependency in fabric.mod.json for published build
+- incremented version number

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.11
 
 # Mod Properties
-	mod_version = 0.3.0-1.19.2
+	mod_version = 0.3.1-1.19.2
 	maven_group = net.thesquire
 	archives_base_name = backroomsmod
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,6 +40,7 @@
     "fabricloader": ">=0.14.11",
     "fabric": ">=0.68.0",
     "techreborn": ">=5.4.0",
+    "immersive_portals": ">=2.2.5",
     "minecraft": "~1.19.2",
     "java": ">=17"
   },


### PR DESCRIPTION
I forgot to re-add the Immersive Portals dependency in the fabric.mod.json file in the previous pull request. This is usually removed during development because I directly use qouteall's libraries instead of the entire Immersive Portals mod, so leaving that dependency in causes a crash when loading Minecraft. However, normal client/server use of the built jar file requires the normal Immersive Portals mod, so this dependency is important to add back in prior to the publishing of a new mod version.